### PR TITLE
fix(providers): fix allanime POST API and plain URL fallback

### DIFF
--- a/providers/allanime.go
+++ b/providers/allanime.go
@@ -1,12 +1,12 @@
 package providers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"regexp"
 	"sort"
 	"strconv"
@@ -61,49 +61,36 @@ func (p *AllAnimeProvider) GetEpisodeInfo(ctx context.Context, mediaID int, epis
 		}, nil
 	}
 
-	// Search for the anime
-	// Note: title is used in JSON, which is properly encoded by json.Marshal
-	// No need for manual escaping
-	searchQuery := `query($search: SearchInput, $limit: Int, $page: Int, $translationType: VaildTranslationTypeEnumType, $countryOrigin: VaildCountryOriginEnumType) {
-		shows(search: $search, limit: $limit, page: $page, translationType: $translationType, countryOrigin: $countryOrigin) {
-			edges {
-				_id
-				name
-				availableEpisodes
-				__typename
-			}
-		}
-	}`
+	// Search for the anime — POST with JSON body (matching jerry.sh)
+	searchQuery := `query($search: SearchInput, $limit: Int, $page: Int, $translationType: VaildTranslationTypeEnumType, $countryOrigin: VaildCountryOriginEnumType) { shows(search: $search, limit: $limit, page: $page, translationType: $translationType, countryOrigin: $countryOrigin) { edges { _id name availableEpisodes __typename } } }`
 
-	variables := map[string]interface{}{
-		"search": map[string]interface{}{
-			"allowAdult":   false,
-			"allowUnknown": false,
-			"query":        title, // JSON encoding handles special characters
+	payload, err := json.Marshal(map[string]interface{}{
+		"variables": map[string]interface{}{
+			"search": map[string]interface{}{
+				"allowAdult":   false,
+				"allowUnknown": false,
+				"query":        title,
+			},
+			"limit":           40,
+			"page":            1,
+			"translationType": "sub",
+			"countryOrigin":   "ALL",
 		},
-		"limit":           40,
-		"page":            1,
-		"translationType": "sub",
-		"countryOrigin":   "ALL",
-	}
-
-	variablesJSON, err := json.Marshal(variables)
+		"query": searchQuery,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal variables: %w", err)
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	params := url.Values{}
-	params.Add("variables", string(variablesJSON))
-	params.Add("query", searchQuery)
-
-	reqURL := fmt.Sprintf("%s?%s", allAnimeAPIURL, params.Encode())
-
-	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, "POST", allAnimeAPIURL, bytes.NewReader(payload))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", allAnimeRefr)
 	req.Header.Set("Referer", allAnimeRefr)
+	req.Header.Set("User-Agent", "Mozilla/5.0")
 
 	resp, err := p.client.Do(req)
 	if err != nil {
@@ -114,6 +101,10 @@ func (p *AllAnimeProvider) GetEpisodeInfo(ctx context.Context, mediaID int, epis
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body[:min(200, len(body))]))
 	}
 
 	var searchResp struct {
@@ -132,15 +123,30 @@ func (p *AllAnimeProvider) GetEpisodeInfo(ctx context.Context, mediaID int, epis
 	}
 
 	if err := json.Unmarshal(body, &searchResp); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal response (status %d): %w", resp.StatusCode, err)
 	}
 
 	if len(searchResp.Data.Shows.Edges) == 0 {
 		return nil, fmt.Errorf("no results found for: %s", title)
 	}
 
-	// Use the first result
+	// Find best matching show — allanime's ranking doesn't always put the exact match first.
+	// Normalize both strings (lowercase, strip non-alphanumeric) and look for an exact match,
+	// then fall back to the result with the most sub episodes (main series has more eps than specials).
+	normalize := func(s string) string {
+		s = strings.ToLower(s)
+		re := regexp.MustCompile(`[^a-z0-9 ]+`)
+		s = re.ReplaceAllString(s, " ")
+		return strings.Join(strings.Fields(s), " ")
+	}
+	titleNorm := normalize(title)
 	show := searchResp.Data.Shows.Edges[0]
+	for _, edge := range searchResp.Data.Shows.Edges {
+		if normalize(edge.Name) == titleNorm {
+			show = edge
+			break
+		}
+	}
 
 	// Save to cache
 	SaveProviderMapping("allanime", mediaID, show.ID, title)
@@ -154,37 +160,30 @@ func (p *AllAnimeProvider) GetEpisodeInfo(ctx context.Context, mediaID int, epis
 
 // GetVideoLink extracts video links from allanime
 func (p *AllAnimeProvider) GetVideoLink(ctx context.Context, episodeInfo *EpisodeInfo, quality string, subOrDub string) (*VideoData, error) {
-	// Fetch episode sources
-	episodeQuery := `query($showId: String!, $translationType: VaildTranslationTypeEnumType!, $episodeString: String!) {
-		episode(showId: $showId, translationType: $translationType, episodeString: $episodeString) {
-			episodeString
-			sourceUrls
-		}
-	}`
+	// Fetch episode sources — POST with JSON body (matching jerry.sh)
+	episodeQuery := `query($showId: String!, $translationType: VaildTranslationTypeEnumType!, $episodeString: String!) { episode(showId: $showId, translationType: $translationType, episodeString: $episodeString) { episodeString sourceUrls } }`
 
-	variables := map[string]interface{}{
-		"showId":          episodeInfo.ShowID,
-		"translationType": subOrDub,
-		"episodeString":   episodeInfo.EpisodeID,
-	}
-
-	variablesJSON, err := json.Marshal(variables)
+	payload, err := json.Marshal(map[string]interface{}{
+		"variables": map[string]interface{}{
+			"showId":          episodeInfo.ShowID,
+			"translationType": subOrDub,
+			"episodeString":   episodeInfo.EpisodeID,
+		},
+		"query": episodeQuery,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal variables: %w", err)
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	params := url.Values{}
-	params.Add("variables", string(variablesJSON))
-	params.Add("query", episodeQuery)
-
-	reqURL := fmt.Sprintf("%s?%s", allAnimeAPIURL, params.Encode())
-
-	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, "POST", allAnimeAPIURL, bytes.NewReader(payload))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", allAnimeRefr)
 	req.Header.Set("Referer", allAnimeRefr)
+	req.Header.Set("User-Agent", "Mozilla/5.0")
 
 	resp, err := p.client.Do(req)
 	if err != nil {
@@ -197,6 +196,10 @@ func (p *AllAnimeProvider) GetVideoLink(ctx context.Context, episodeInfo *Episod
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body[:min(200, len(body))]))
+	}
+
 	var episodeResp struct {
 		Data struct {
 			Episode struct {
@@ -206,7 +209,7 @@ func (p *AllAnimeProvider) GetVideoLink(ctx context.Context, episodeInfo *Episod
 	}
 
 	if err := json.Unmarshal(body, &episodeResp); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal response (status %d): %w", resp.StatusCode, err)
 	}
 
 	// Check if SourceUrls is empty or null
@@ -240,67 +243,77 @@ type sourceURLEntry struct {
 	Type       string `json:"type"`
 }
 
+// plainURLPriority defines preferred plain-URL sources (mpv+yt-dlp can handle these)
+var plainURLPriority = []string{"Fm-Hls", "Sup", "Uni", "Sw", "Mp4", "Ok", "Vg"}
+
 // extractLinks extracts video links from source URLs
 func (p *AllAnimeProvider) extractLinks(ctx context.Context, sourceURLs json.RawMessage) (map[string]string, error) {
-	// Try to parse as array of sourceURLEntry
 	var sources []sourceURLEntry
 	if err := json.Unmarshal(sourceURLs, &sources); err != nil {
-		// Fallback to old string manipulation for backward compatibility
 		return p.extractLinksLegacy(ctx, sourceURLs)
 	}
 
-	// Build resp string with sourceName :sourceUrl format
-	var resp strings.Builder
+	// Separate plain URLs (playable by mpv/yt-dlp) from CDN-encoded ones
+	plainURLs := make(map[string]string) // sourceName -> url
+	var encodedResp strings.Builder
 	for _, source := range sources {
-		// Extract the encoded URL (remove "--" prefix if present)
-		sourceURL := source.SourceURL
-		if strings.HasPrefix(sourceURL, "--") {
-			sourceURL = sourceURL[2:]
+		url := source.SourceURL
+		if strings.HasPrefix(url, "--") {
+			encoded := url[2:]
+			if encoded != "" && source.SourceName != "" {
+				encodedResp.WriteString(fmt.Sprintf("%s :%s\n", source.SourceName, encoded))
+			}
+		} else if url != "" && source.SourceName != "" &&
+			(strings.HasPrefix(url, "http") || strings.HasPrefix(url, "//")) {
+			plainURLs[source.SourceName] = url
 		}
+	}
 
-		if sourceURL != "" && source.SourceName != "" {
-			// Format: "sourceName :sourceUrl" (space before colon, no space after)
-			resp.WriteString(fmt.Sprintf("%s :%s\n", source.SourceName, sourceURL))
+	// Try CDN encoded sources first
+	if encodedResp.Len() > 0 {
+		type result struct {
+			links map[string]string
+			err   error
 		}
-	}
-	respStr := resp.String()
-
-	if respStr == "" {
-		return nil, fmt.Errorf("no source URLs found in response")
-	}
-
-	// Try all 5 providers in parallel (like jerry.sh does)
-	type providerResult struct {
-		links map[string]string
-		err   error
-	}
-	
-	results := make(chan providerResult, 5)
-	
-	// Try each provider (1-5) like jerry.sh
-	for providerNum := 1; providerNum <= 5; providerNum++ {
-		go func(num int) {
-			links, err := p.generateLinksForProvider(ctx, respStr, num)
-			results <- providerResult{links: links, err: err}
-		}(providerNum)
-	}
-	
-	// Collect all results
-	allLinks := make(map[string]string)
-	for i := 0; i < 5; i++ {
-		result := <-results
-		if result.err == nil && len(result.links) > 0 {
-			for quality, link := range result.links {
-				allLinks[quality] = link
+		ch := make(chan result, 5)
+		for num := 1; num <= 5; num++ {
+			go func(n int) {
+				links, err := p.generateLinksForProvider(ctx, encodedResp.String(), n)
+				ch <- result{links, err}
+			}(num)
+		}
+		allLinks := make(map[string]string)
+		for i := 0; i < 5; i++ {
+			r := <-ch
+			if r.err == nil {
+				for q, l := range r.links {
+					allLinks[q] = l
+				}
 			}
 		}
+		if len(allLinks) > 0 {
+			return allLinks, nil
+		}
 	}
-	
-	if len(allLinks) == 0 {
-		return nil, fmt.Errorf("no video links found: all providers failed")
+
+	// CDN failed — fall back to plain URLs in priority order
+	for _, name := range plainURLPriority {
+		if url, ok := plainURLs[name]; ok {
+			if strings.HasPrefix(url, "//") {
+				url = "https:" + url
+			}
+			return map[string]string{"best": url}, nil
+		}
 	}
-	
-	return allLinks, nil
+	// Any remaining plain URL
+	for _, url := range plainURLs {
+		if strings.HasPrefix(url, "//") {
+			url = "https:" + url
+		}
+		return map[string]string{"best": url}, nil
+	}
+
+	return nil, fmt.Errorf("no video links found: all sources failed")
 }
 
 // extractLinksLegacy is a fallback that uses string manipulation for backward compatibility

--- a/providers/aniwatch.go
+++ b/providers/aniwatch.go
@@ -39,6 +39,23 @@ func (p *AniWatchProvider) Name() string {
 	return "aniwatch"
 }
 
+// hiAnimeLines extracts the HTML from a hianime AJAX response (which wraps HTML in a JSON
+// envelope) and returns it split into one-tag-per-line, matching jerry.sh's approach of
+// `sed "s/</\n/g; s/\\\//g"`.
+func hiAnimeLines(body []byte) []string {
+	// Try to unwrap the JSON envelope {"html":"..."}
+	var envelope struct {
+		HTML string `json:"html"`
+	}
+	html := string(body)
+	if err := json.Unmarshal(body, &envelope); err == nil && envelope.HTML != "" {
+		html = envelope.HTML
+	}
+	// Unescape JSON-encoded forward slashes and split on "<"
+	html = strings.ReplaceAll(html, `\/`, `/`)
+	return strings.Split(html, "<")
+}
+
 // GetEpisodeInfo fetches episode information from aniwatch
 func (p *AniWatchProvider) GetEpisodeInfo(ctx context.Context, mediaID int, episodeNum int, title string) (*EpisodeInfo, error) {
 	// Fetch aniwatch ID from mal-backup
@@ -60,20 +77,42 @@ func (p *AniWatchProvider) GetEpisodeInfo(ctx context.Context, mediaID int, epis
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
-	// Extract aniwatch ID
-	re := regexp.MustCompile(`"Zoro".*?"url":".*-([0-9]+)"`)
-	matches := re.FindStringSubmatch(string(body))
+	// Parse the backup JSON and extract the hianime show ID from known site keys.
+	// The URL format is "https://<domain>/<slug>-<id>" — we want the trailing numeric ID.
+	var backup struct {
+		Sites map[string]map[string]struct {
+			URL string `json:"url"`
+		} `json:"Sites"`
+	}
+	if err := json.Unmarshal(body, &backup); err != nil {
+		return nil, fmt.Errorf("failed to parse backup JSON: %w", err)
+	}
 
-	if len(matches) < 2 {
+	var aniwatchID string
+	reTrailingID := regexp.MustCompile(`-(\d+)$`)
+	for _, key := range []string{"Zoro", "Aniwatch", "Zoro-1"} {
+		entries, ok := backup.Sites[key]
+		if !ok {
+			continue
+		}
+		for _, entry := range entries {
+			if m := reTrailingID.FindStringSubmatch(strings.TrimRight(entry.URL, "/")); len(m) >= 2 {
+				aniwatchID = m[1]
+				break
+			}
+		}
+		if aniwatchID != "" {
+			break
+		}
+	}
+
+	if aniwatchID == "" {
 		return nil, fmt.Errorf("aniwatch ID not found for media ID %d", mediaID)
 	}
 
-	aniwatchID := matches[1]
-
 	// Fetch episode list
-	episodeListURL := fmt.Sprintf("https://hianime.to/ajax/v2/episode/list/%s", aniwatchID)
-
-	req, err = http.NewRequestWithContext(ctx, "GET", episodeListURL, nil)
+	req, err = http.NewRequestWithContext(ctx, "GET",
+		fmt.Sprintf("https://hianime.to/ajax/v2/episode/list/%s", aniwatchID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -89,26 +128,58 @@ func (p *AniWatchProvider) GetEpisodeInfo(ctx context.Context, mediaID int, epis
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
-	// Parse episode data
-	reEp := regexp.MustCompile(fmt.Sprintf(`a title="([^"]*)".*?data-id="([0-9]*)".*?Episode %d`, episodeNum))
-	matchesEp := reEp.FindStringSubmatch(string(body))
+	// Parse episode list: split on "<" (jerry.sh approach) then match per line.
+	// Each episode anchor looks like: a title="Ep Title" ... data-number="N" ... data-id="12345"
+	reEpLine := regexp.MustCompile(`a\s[^>]*title="([^"]*)"[^>]*data-id="(\d+)"`)
+	reDataNum := regexp.MustCompile(`data-number="(\d+)"`)
 
-	if len(matchesEp) < 3 {
+	var episodeID, episodeTitle string
+	for _, line := range hiAnimeLines(body) {
+		m := reEpLine.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		// Prefer data-number attribute for matching the episode
+		numMatch := reDataNum.FindStringSubmatch(line)
+		if numMatch != nil {
+			if numMatch[1] == fmt.Sprintf("%d", episodeNum) {
+				episodeTitle = m[1]
+				episodeID = m[2]
+				break
+			}
+		}
+	}
+
+	// Fallback: take the Nth anchor (1-indexed) if data-number wasn't found
+	if episodeID == "" {
+		count := 0
+		for _, line := range hiAnimeLines(body) {
+			if m := reEpLine.FindStringSubmatch(line); m != nil {
+				count++
+				if count == episodeNum {
+					episodeTitle = m[1]
+					episodeID = m[2]
+					break
+				}
+			}
+		}
+	}
+
+	if episodeID == "" {
 		return nil, fmt.Errorf("episode %d not found", episodeNum)
 	}
 
 	return &EpisodeInfo{
-		EpisodeID:    matchesEp[2],
-		EpisodeTitle: matchesEp[1],
+		EpisodeID:    episodeID,
+		EpisodeTitle: episodeTitle,
 	}, nil
 }
 
 // GetVideoLink extracts video links from aniwatch
 func (p *AniWatchProvider) GetVideoLink(ctx context.Context, episodeInfo *EpisodeInfo, quality string, subOrDub string) (*VideoData, error) {
-	// Get server ID
-	serverURL := fmt.Sprintf("https://hianime.to/ajax/v2/episode/servers?episodeId=%s", episodeInfo.EpisodeID)
-
-	req, err := http.NewRequestWithContext(ctx, "GET", serverURL, nil)
+	// Get server list
+	req, err := http.NewRequestWithContext(ctx, "GET",
+		fmt.Sprintf("https://hianime.to/ajax/v2/episode/servers?episodeId=%s", episodeInfo.EpisodeID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -124,25 +195,27 @@ func (p *AniWatchProvider) GetVideoLink(ctx context.Context, episodeInfo *Episod
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
-	// Extract server ID for requested type
-	reServer := regexp.MustCompile(fmt.Sprintf(`data-type="%s" data-id="([0-9]*)"`, subOrDub))
-	matchesServer := reServer.FindStringSubmatch(string(body))
-
-	if len(matchesServer) < 2 {
-		// Fallback to raw
-		reServer = regexp.MustCompile(`data-type="raw" data-id="([0-9]*)"`)
-		matchesServer = reServer.FindStringSubmatch(string(body))
-		if len(matchesServer) < 2 {
-			return nil, fmt.Errorf("no server found")
+	// Extract server ID — split on "<" then match per line (jerry.sh approach)
+	reServerLine := regexp.MustCompile(`data-type="([^"]*)"[^>]*data-id="(\d+)"`)
+	var sourceID string
+	for _, preferred := range []string{subOrDub, "raw"} {
+		for _, line := range hiAnimeLines(body) {
+			if m := reServerLine.FindStringSubmatch(line); m != nil && m[1] == preferred {
+				sourceID = m[2]
+				break
+			}
+		}
+		if sourceID != "" {
+			break
 		}
 	}
-
-	sourceID := matchesServer[1]
+	if sourceID == "" {
+		return nil, fmt.Errorf("no server found")
+	}
 
 	// Get embed link
-	embedURL := fmt.Sprintf("https://hianime.to/ajax/v2/episode/sources?id=%s", sourceID)
-
-	req, err = http.NewRequestWithContext(ctx, "GET", embedURL, nil)
+	req, err = http.NewRequestWithContext(ctx, "GET",
+		fmt.Sprintf("https://hianime.to/ajax/v2/episode/sources?id=%s", sourceID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -161,15 +234,13 @@ func (p *AniWatchProvider) GetVideoLink(ctx context.Context, episodeInfo *Episod
 	var embedResp struct {
 		Link string `json:"link"`
 	}
-
 	if err := json.Unmarshal(body, &embedResp); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal embed response: %w", err)
 	}
 
 	// Parse embed link
 	reEmbed := regexp.MustCompile(`(.*)/embed-([246])/e-([0-9])/(.*)\?k=1`)
 	matchesEmbed := reEmbed.FindStringSubmatch(embedResp.Link)
-
 	if len(matchesEmbed) < 5 {
 		return nil, fmt.Errorf("invalid embed link format")
 	}
@@ -180,13 +251,11 @@ func (p *AniWatchProvider) GetVideoLink(ctx context.Context, episodeInfo *Episod
 	embedSourceID := matchesEmbed[4]
 
 	// Get actual source
-	sourceURL := fmt.Sprintf("%s/embed-%s/ajax/e-%s/getSources?id=%s", providerLink, embedType, eNumber, embedSourceID)
-
-	req, err = http.NewRequestWithContext(ctx, "GET", sourceURL, nil)
+	req, err = http.NewRequestWithContext(ctx, "GET",
+		fmt.Sprintf("%s/embed-%s/ajax/e-%s/getSources?id=%s", providerLink, embedType, eNumber, embedSourceID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
-
 	req.Header.Set("X-Requested-With", "XMLHttpRequest")
 
 	resp, err = p.client.Do(req)
@@ -200,29 +269,24 @@ func (p *AniWatchProvider) GetVideoLink(ctx context.Context, episodeInfo *Episod
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
-	// Parse video link
-	reVideo := regexp.MustCompile(`"file":"(.*\.m3u8)"`)
+	// Parse video link — JSON response, "file" field ending in .m3u8
+	reVideo := regexp.MustCompile(`"file"\s*:\s*"([^"]*\.m3u8)"`)
 	matchesVideo := reVideo.FindStringSubmatch(string(body))
-
 	if len(matchesVideo) < 2 {
 		return nil, fmt.Errorf("video link not found")
 	}
 
-	videoURL := matchesVideo[1]
-
-	// Apply quality if specified
+	videoURL := strings.ReplaceAll(matchesVideo[1], `\/`, `/`)
 	if quality != "" {
 		videoURL = strings.Replace(videoURL, "/playlist.m3u8", fmt.Sprintf("/%s/index.m3u8", quality), 1)
 	}
 
 	// Extract subtitles
-	reSubs := regexp.MustCompile(`"file":"([^"]*\.vtt)"`)
-	matchesSubs := reSubs.FindAllStringSubmatch(string(body), -1)
-
+	reSubs := regexp.MustCompile(`"file"\s*:\s*"([^"]*\.vtt)"`)
 	var subtitles []string
-	for _, match := range matchesSubs {
-		if len(match) >= 2 {
-			subtitles = append(subtitles, match[1])
+	for _, m := range reSubs.FindAllStringSubmatch(string(body), -1) {
+		if len(m) >= 2 {
+			subtitles = append(subtitles, strings.ReplaceAll(m[1], `\/`, `/`))
 		}
 	}
 
@@ -231,4 +295,3 @@ func (p *AniWatchProvider) GetVideoLink(ctx context.Context, episodeInfo *Episod
 		SubtitleURLs: subtitles,
 	}, nil
 }
-


### PR DESCRIPTION
- switch allanime search and episode queries from GET to POST with JSON body; the API no longer accepts query params
- add Origin, Referer, User-Agent headers required by the API
- check HTTP status before unmarshalling to surface real errors
- normalize titles before matching to handle cases where the exact match isn't ranked first (e.g. FMAB vs Reflections)
- fall back to plain iframe URLs (Fm-Hls, Sup, Mp4, Ok, etc.) when allanime CDN encoded sources fail; mpv/yt-dlp handles these natively
- rewrite aniwatch backup JSON parsing to use typed struct unmarshal instead of fragile multiline regex
- add hiAnimeLines helper matching jerry.sh HTML splitting approach
- fix episode matching to use data-number attribute with positional fallback instead of brittle Episode N text match
- make video/subtitle regexes space-tolerant and unescape \/ in URLs